### PR TITLE
Update risk_assessor.pyUpdate risk_assessor.py Update risk_assessor.py to calculate risk based on revealed neighborsto calculate risk base…

### DIFF
--- a/src/ai_minesweeper/risk_assessor.py
+++ b/src/ai_minesweeper/risk_assessor.py
@@ -4,12 +4,24 @@ class RiskAssessor:
     """Very naïve probability map."""
 
     @staticmethod
-    def estimate(board: Board) -> dict[tuple[int, int], float]:
+        @staticmethod
+    def estimate(board) -> dict[tuple[int, int], float]:
         risk_map: dict[tuple[int, int], float] = {}
         for r, row in enumerate(board.grid):
             for c, cell in enumerate(row):
                 if cell.state == State.HIDDEN:
-                    risk_map[(r, c)] = 0.15  # placeholder uniform risk
+                    # Check revealed neighbors
+                    revealed_neighbors = [board.grid[nr][nc] for nr, nc in board.get_neighbors(r, c) if board.grid[nr][nc].state == State.REVEALED]
+                    if any(neighbor.adjacent_mines == 0 for neighbor in revealed_neighbors):
+                        risk_map[(r, c)] = 0.0
+                    else:
+                        # Calculate risk based on revealed neighbors
+                        sum_neighbor_counts = sum(neighbor.adjacent_mines for neighbor in revealed_neighbors)
+                        num_hidden_neighbors = len([1 for nr, nc in board.get_neighbors(r, c) if board.grid[nr][nc].state == State.HIDDEN])
+                        if num_hidden_neighbors > 0:
+                            risk_map[(r, c)] = sum_neighbor_counts / (num_hidden_neighbors * 8)
+                        else:
+                            risk_map[(r, c)] = 1.0
                 elif cell.is_mine:
                     risk_map[(r, c)] = 1.0
                 else:


### PR DESCRIPTION
This PR updates the `estimate` method in `risk_assessor.py` to calculate the risk for each hidden cell based on its revealed neighbors. If a neighbor has a count of 0, the risk is set to 0.0. Otherwise, the risk is calculated as `(sum of neighbor counts) / (num hidden neighbors × 8)`. Revealed cells have a risk of 0.0, and mines have a risk of 1.0.