### PR TITLE
Update click_engine.py to select hidden cell with lowest risk

### DIFF
--- a/src/ai_minesweeper/click_engine.py
+++ b/src/ai_minesweeper/click_engine.py
@@ -6,7 +6,11 @@ class ClickEngine:
     """Select the next cell to click."""
 
     @staticmethod
+    def     @staticmethod
     def next_click(board: Board) -> tuple[int, int]:
-        """Return the unrevealed cell with lowest estimated risk (placeholder)."""
+        """Return the hidden cell with the lowest estimated risk."""
         risks = RiskAssessor.estimate(board)
-        return min(risks, key=risks.get, default=(0, 0))
+        # Filter for hidden cells
+        hidden_cells = {(r, c): risk for (r, c), risk in risks.items() if board.grid[r][c].state == State.HIDDEN}
+        # Return the hidden cell with the lowest risk, prioritizing lowest row and column in case of ties
+        return min(hidden_cells, key=lambda cell: (hidden_cells[cell], cell))        return min(risks, key=risks.get, default=(0, 0))


### PR DESCRIPTION
This PR updates the `next_click` method in `click_engine.py` to select the hidden cell with the lowest estimated risk. It calls `RiskAssessor.estimate`, filters for hidden cells, and returns the one with the lowest risk, prioritizing the lowest row and column in case of ties.